### PR TITLE
Change seed node configuration in master system to use same host and port as master node.

### DIFF
--- a/ddm-lmp/src/main/java/de/hpi/ddm/MasterSystem.java
+++ b/ddm-lmp/src/main/java/de/hpi/ddm/MasterSystem.java
@@ -28,7 +28,7 @@ public class MasterSystem {
 				"akka.remote.artery.canonical.hostname = \"" + c.getHost() + "\"\n" +
 				"akka.remote.artery.canonical.port = " + c.getPort() + "\n" +
 				"akka.cluster.roles = [" + MASTER_ROLE + "]\n" +
-				"akka.cluster.seed-nodes = [\"akka://" + c.getActorSystemName() + "@" + c.getMasterHost() + ":" + c.getMasterPort() + "\"]")
+				"akka.cluster.seed-nodes = [\"akka://" + c.getActorSystemName() + "@" + c.getHost() + ":" + c.getPort() + "\"]")
 			.withFallback(ConfigFactory.load("application"));
 		
 		final ActorSystem system = ActorSystem.create(c.getActorSystemName(), config);


### PR DESCRIPTION
Without this change the worker actors in the master system can not connect to the master if the host or port was changed. 

Example: `java -cp .\target\ddm-lmp-1.0.jar de.hpi.ddm.Main master -h 127.0.0.1` fails.